### PR TITLE
Dockerfile optimized for a smaller and more portable resulting image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM golang:1.19-alpine
-RUN mkdir /app
-COPY . /app
+FROM golang:1.19-alpine as build
+
 WORKDIR /app
-RUN go build -o server .
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o server .
+
+FROM alpine:3.18.3
+
+WORKDIR /app
+
+COPY --from=build /app .
+
 VOLUME [ "/app/dbdata", "/app/files" ]
+
 ENTRYPOINT [ "/app/server" ]
+
 CMD [ "-logtype", "json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ FROM alpine:3.18.3
 
 WORKDIR /app
 
-COPY --from=build /app .
+COPY --from=build /app/server .
+COPY --from=build /app/static ./static
 
 VOLUME [ "/app/dbdata", "/app/files" ]
 


### PR DESCRIPTION
Dockerfile optimized by setting up multi-stage building and CGO disabled on go build for a faster and more portable build.

The final image has been reduced from a 983 Mb to a 66.1 Mb image.

![Screenshot from 2023-09-16 11-31-52](https://github.com/DavidsonGomes/wuzapi/assets/80290114/9307adc8-3abc-43fe-9f1b-027b8be57c8a)
